### PR TITLE
allow for other sync protocols

### DIFF
--- a/data.proto
+++ b/data.proto
@@ -295,10 +295,10 @@ message Sync {
     bool                validate        = 1;
     int64               buffer          = 2;
     int64               write_workers   = 3;
-    repeated GNMISync   gnmi            = 4;
+    repeated SyncConfig config            = 4;
 }
 
-message GNMISync {
+message SyncConfig {
     // sync routing name
     string name = 1;
     // paths to subscribe to
@@ -309,6 +309,8 @@ message GNMISync {
     string encoding = 4;
     // interval for mode sample or once
     uint64 interval = 5;
+    // protocol used to sync the config
+    string protocol = 6;
 }
 
 enum SyncMode {


### PR DESCRIPTION
If we want to add netconf or other protocols we might want to add a protocol in the sync section.
