### PR TITLE
BlameTreeElement: Change the rendering of a deviated running

### DIFF
--- a/sdcpb/blame_tree_element_additions.go
+++ b/sdcpb/blame_tree_element_additions.go
@@ -62,7 +62,7 @@ func (b *BlameTreeElement) StringIndent(sb *strings.Builder, prefix string, isLa
 	// Compose value string
 	value := ""
 	if b.GetValue() != nil {
-		value = fmt.Sprintf(" -> %s", b.Value.ToString())
+		value = fmt.Sprintf(" -> %s", b.GetValue().ToString())
 		icon = "🍃 "
 	}
 
@@ -70,7 +70,8 @@ func (b *BlameTreeElement) StringIndent(sb *strings.Builder, prefix string, isLa
 	deviated_value := ""
 	if b.IsDeviated() {
 		deviated = "(*)"
-		deviated_value = fmt.Sprintf(" [-> %s]", b.GetDeviationValue().ToString())
+		value = fmt.Sprintf(" -> %s", b.GetDeviationValue().ToString())
+		deviated_value = fmt.Sprintf(" [~> %s]", b.GetValue().ToString())
 	}
 
 	// Write this node


### PR DESCRIPTION
This is changing the output for a devated value from
`<intent-name>      <parameter> -> <expected> [ -> <actual>]`
to
`<intent-name>      <parameter> -> <actual> [ ~> <expected>]`
This results in the right side always represents the running config  and the expected value is seperated out into the braces.