### PR TITLE
render multiline and long blame tree values as indented blocks

### DIFF
--- a/sdcpb/blame_tree_element_additions.go
+++ b/sdcpb/blame_tree_element_additions.go
@@ -3,9 +3,140 @@ package sdcpb
 import (
 	"fmt"
 	"iter"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
+
+const (
+	defaultValueWrapWidth = 96
+	inlineValueMaxLen     = 80
+	continuationOwnerID   = "..."
+	blockValueIndent      = "  "
+	minValueWrapWidth     = 24
+)
+
+var OriginalLineBreakMarker = "\\n"
+
+type renderedValueLine struct {
+	text               string
+	hasOriginalNewline bool
+}
+
+func normalizeLineBreaks(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return s
+}
+
+func shouldRenderValueBlock(s string) bool {
+	s = normalizeLineBreaks(s)
+	if strings.Contains(s, "\n") {
+		return true
+	}
+	return len([]rune(s)) > inlineValueMaxLen
+}
+
+func wrapTextFixedWidth(s string, width int) []string {
+	if width <= 0 {
+		return []string{s}
+	}
+
+	runes := []rune(s)
+	if len(runes) <= width {
+		return []string{s}
+	}
+
+	parts := make([]string, 0, (len(runes)/width)+1)
+	for len(runes) > width {
+		parts = append(parts, string(runes[:width]))
+		runes = runes[width:]
+	}
+	parts = append(parts, string(runes))
+	return parts
+}
+
+func splitValueLines(s string, width int) []renderedValueLine {
+	s = strings.TrimRight(normalizeLineBreaks(s), "\n")
+	if s == "" {
+		return []renderedValueLine{{text: ""}}
+	}
+
+	raw := strings.Split(s, "\n")
+	out := make([]renderedValueLine, 0, len(raw))
+	for i, line := range raw {
+		wrapped := wrapTextFixedWidth(line, width)
+		for j, w := range wrapped {
+			out = append(out, renderedValueLine{
+				text:               w,
+				hasOriginalNewline: i > 0 && j == 0,
+			})
+		}
+	}
+	return out
+}
+
+func resolveRenderLineWidth() int {
+	if v := os.Getenv("SDC_BLAME_WRAP_WIDTH"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	if n := detectTerminalWidth(); n > 0 {
+		return n
+	}
+
+	if v := os.Getenv("COLUMNS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultValueWrapWidth
+}
+
+func detectTerminalWidth() int {
+	for _, fd := range []uintptr{os.Stdout.Fd(), os.Stderr.Fd(), os.Stdin.Fd()} {
+		ws, err := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
+		if err == nil && ws != nil && ws.Col > 0 {
+			return int(ws.Col)
+		}
+	}
+	return 0
+}
+
+func effectiveValueWrapWidth(ownerSize int, prefix string, isLast bool) int {
+	totalLineWidth := resolveRenderLineWidth()
+	linePrefix := fmt.Sprintf("%*s%s │ %s%s%s", ownerSize, continuationOwnerID, "   ", prefix, continuationBranch(isLast), blockValueIndent)
+	wrapWidth := totalLineWidth - len([]rune(linePrefix)) - len([]rune(OriginalLineBreakMarker))
+	if wrapWidth < minValueWrapWidth {
+		return minValueWrapWidth
+	}
+	return wrapWidth
+}
+
+func continuationBranch(isLast bool) string {
+	if isLast {
+		return "    "
+	}
+	return "│   "
+}
+
+func writeValueContinuationLines(sb *strings.Builder, ownerSize int, prefix string, isLast bool, lines []renderedValueLine) {
+	branch := continuationBranch(isLast)
+	linePrefix := fmt.Sprintf("%*s%s │ %s%s%s", ownerSize, continuationOwnerID, "   ", prefix, branch, blockValueIndent)
+	for i, line := range lines {
+		sb.WriteString(linePrefix)
+		sb.WriteString(line.text)
+		if i+1 < len(lines) && lines[i+1].hasOriginalNewline {
+			sb.WriteString(OriginalLineBreakMarker)
+		}
+		sb.WriteString("\n")
+	}
+}
 
 func NewBlameTreeElement(name string) *BlameTreeElement {
 	return &BlameTreeElement{Name: name}
@@ -65,6 +196,9 @@ func (b *BlameTreeElement) GetPath(parentPath *Path) *Path {
 
 func (b *BlameTreeElement) CalculateMaxOwnerLength() int {
 	maxLen := len(b.OwnerNormalized())
+	if len(continuationOwnerID) > maxLen {
+		maxLen = len(continuationOwnerID)
+	}
 	for _, c := range b.GetChilds() {
 		childMax := c.CalculateMaxOwnerLength()
 		if childMax > maxLen {
@@ -97,24 +231,52 @@ func (b *BlameTreeElement) StringIndent(sb *strings.Builder, prefix string, isLa
 	}
 
 	// Compose value string
-	value := ""
 	deviated := "   "
-	deviated_value := ""
 
 	switch {
 	case b.GetKeyName() != "":
 		icon = fmt.Sprintf("🔑 %s=", b.GetKeyName())
 	case b.IsDeviated():
 		deviated = "(*)"
-		value = fmt.Sprintf(" -> %s", b.GetDeviationValue().ToString())
-		deviated_value = fmt.Sprintf(" [~> %s]", b.GetValue().ToString())
 	case b.GetValue() != nil:
-		value = fmt.Sprintf(" -> %s", b.GetValue().ToString())
 		icon = "🍃 "
 	}
 
-	// Write this node
-	sb.WriteString(fmt.Sprintf("%*s%s │ %s%s%s%s%s%s\n", ownerSize, b.OwnerNormalized(), deviated, prefix, connector, icon, b.Name, value, deviated_value))
+	linePrefix := fmt.Sprintf("%*s%s │ %s%s%s%s", ownerSize, b.OwnerNormalized(), deviated, prefix, connector, icon, b.Name)
+	// Write this node and value payload.
+	if b.IsDeviated() {
+		newValue := b.GetDeviationValue().ToString()
+		oldValue := b.GetValue().ToString()
+		wrapWidth := effectiveValueWrapWidth(ownerSize, prefix, isLast)
+		if shouldRenderValueBlock(newValue) || shouldRenderValueBlock(oldValue) {
+			sb.WriteString(linePrefix)
+			sb.WriteString(" ->")
+			sb.WriteString("\n")
+			writeValueContinuationLines(sb, ownerSize, prefix, isLast, splitValueLines(newValue, wrapWidth))
+			sb.WriteString(fmt.Sprintf("%*s%s │ %s%s%s[~>]\n", ownerSize, continuationOwnerID, "   ", prefix, continuationBranch(isLast), blockValueIndent))
+			writeValueContinuationLines(sb, ownerSize, prefix, isLast, splitValueLines(oldValue, wrapWidth))
+		} else {
+			sb.WriteString(linePrefix)
+			sb.WriteString(fmt.Sprintf(" -> %s [~> %s]\n", newValue, oldValue))
+		}
+	} else if b.GetValue() != nil {
+		value := b.GetValue().ToString()
+		wrapWidth := effectiveValueWrapWidth(ownerSize, prefix, isLast)
+		if shouldRenderValueBlock(value) {
+			sb.WriteString(linePrefix)
+			sb.WriteString(" ->")
+			sb.WriteString("\n")
+			writeValueContinuationLines(sb, ownerSize, prefix, isLast, splitValueLines(value, wrapWidth))
+		} else {
+			sb.WriteString(linePrefix)
+			sb.WriteString(" -> ")
+			sb.WriteString(value)
+			sb.WriteString("\n")
+		}
+	} else {
+		sb.WriteString(linePrefix)
+		sb.WriteString("\n")
+	}
 
 	// Write children
 	cCount := b.ChildCount()

--- a/sdcpb/blame_tree_element_additions_test.go
+++ b/sdcpb/blame_tree_element_additions_test.go
@@ -1,0 +1,152 @@
+package sdcpb
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToStringMultilineLeafValueKeepsTreePrefix(t *testing.T) {
+	root := NewBlameTreeElement("root")
+	root.AddChild(
+		NewBlameTreeElement("certificate").
+			SetOwner("running").
+			SetValue(&TypedValue{Value: &TypedValue_StringVal{StringVal: "line1\nline2\nline3"}}),
+	)
+
+	out := root.ToString()
+	lines := strings.Split(out, "\n")
+
+	if len(lines) < 4 {
+		t.Fatalf("unexpected output line count: got %d, output:\n%s", len(lines), out)
+	}
+
+	if !strings.Contains(out, "certificate ->") {
+		t.Fatalf("expected header line for multiline value, got:\n%s", out)
+	}
+	if !strings.Contains(out, "...") {
+		t.Fatalf("expected continuation owner marker, got:\n%s", out)
+	}
+	if !strings.Contains(out, "line1\\n") || !strings.Contains(out, "line2\\n") {
+		t.Fatalf("expected original newline markers in continuation lines, got:\n%s", out)
+	}
+
+	for _, line := range lines {
+		if strings.Contains(line, "line2") || strings.Contains(line, "line3") {
+			if !strings.Contains(line, "│") {
+				t.Fatalf("continuation line lost tree prefix: %q", line)
+			}
+			if strings.HasPrefix(line, "line2") || strings.HasPrefix(line, "line3") {
+				t.Fatalf("continuation line is unprefixed: %q", line)
+			}
+		}
+	}
+}
+
+func TestToStringMultilineDeviatedValueKeepsTreePrefix(t *testing.T) {
+	root := NewBlameTreeElement("root")
+	root.AddChild(
+		NewBlameTreeElement("certificate").
+			SetOwner("running").
+			SetValue(&TypedValue{Value: &TypedValue_StringVal{StringVal: "old1\nold2"}}).
+			SetDeviationValue(&TypedValue{Value: &TypedValue_StringVal{StringVal: "new1\nnew2"}}),
+	)
+
+	out := root.ToString()
+	lines := strings.Split(out, "\n")
+
+	if !strings.Contains(out, "certificate ->") {
+		t.Fatalf("expected deviated header line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[~>]") {
+		t.Fatalf("expected output to contain old value marker, got:\n%s", out)
+	}
+
+	for _, line := range lines {
+		if strings.Contains(line, "new2") || strings.Contains(line, "old2") {
+			if !strings.Contains(line, "│") {
+				t.Fatalf("continuation line lost tree prefix: %q", line)
+			}
+			if strings.HasPrefix(line, "new2") || strings.HasPrefix(line, "old2") {
+				t.Fatalf("continuation line is unprefixed: %q", line)
+			}
+		}
+	}
+}
+
+func TestToStringLongLeafValueWrapsWithPrefix(t *testing.T) {
+	root := NewBlameTreeElement("root")
+	longLine := strings.Repeat("A", defaultValueWrapWidth+20)
+	root.AddChild(
+		NewBlameTreeElement("key").
+			SetOwner("running").
+			SetValue(&TypedValue{Value: &TypedValue_StringVal{StringVal: longLine}}),
+	)
+
+	out := root.ToString()
+	lines := strings.Split(out, "\n")
+
+	if len(lines) < 3 {
+		t.Fatalf("expected wrapped continuation line, got %d lines:\n%s", len(lines), out)
+	}
+	if !strings.Contains(out, "key ->") {
+		t.Fatalf("expected long value to switch to block mode, got:\n%s", out)
+	}
+
+	wrappedChunk := strings.Repeat("A", 20)
+	foundWrapped := false
+	for _, line := range lines {
+		if strings.Contains(line, wrappedChunk) && strings.Contains(line, "│") {
+			foundWrapped = true
+			break
+		}
+	}
+	if !foundWrapped {
+		t.Fatalf("expected wrapped continuation chunk with tree prefix, got:\n%s", out)
+	}
+	if strings.Contains(out, "\\n ") {
+		t.Fatalf("did not expect original newline marker for soft wraps, got:\n%s", out)
+	}
+}
+
+func TestToStringTrailingNewlineDoesNotEmitExtraEmptyContinuationLine(t *testing.T) {
+	root := NewBlameTreeElement("root")
+	root.AddChild(
+		NewBlameTreeElement("certificate").
+			SetOwner("running").
+			SetValue(&TypedValue{Value: &TypedValue_StringVal{StringVal: "line1\nline2\n"}}),
+	)
+
+	out := root.ToString()
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(strings.TrimPrefix(line, "...")) == "│" {
+			t.Fatalf("found empty continuation line: %q", line)
+		}
+	}
+}
+
+func TestToStringContinuationKeepsSiblingBranchVisible(t *testing.T) {
+	root := NewBlameTreeElement("root")
+	profile := NewBlameTreeElement("profile")
+	profile.AddChild(
+		NewBlameTreeElement("certificate").
+			SetOwner("running").
+			SetValue(&TypedValue{Value: &TypedValue_StringVal{StringVal: "line1\nline2"}}),
+	)
+	profile.AddChild(
+		NewBlameTreeElement("cipher-list").
+			SetOwner("default").
+			SetValue(&TypedValue{Value: &TypedValue_StringVal{StringVal: "c1"}}),
+	)
+	root.AddChild(profile)
+
+	out := root.ToString()
+
+	if !strings.Contains(out, "certificate ->") || !strings.Contains(out, "cipher-list -> c1") {
+		t.Fatalf("expected both certificate block and sibling line, got:\n%s", out)
+	}
+
+	if !strings.Contains(out, "...") || !strings.Contains(out, "line1\\n") || !strings.Contains(out, "│     line2") {
+		t.Fatalf("expected continuation line to keep branch pipe, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
- Split multiline/long leaf values into block-mode continuation lines instead of rendering inline, which broke tree column alignment
- Wrap long lines at terminal width (ioctl TIOCGWINSZ, with SDC_BLAME_WRAP_WIDTH env override, COLUMNS fallback, default 96)
- Mark source newlines with OriginalLineBreakMarker (default "\\n") at end of the preceding line; exposed as overridable package variable
- Keep branch connectors alive for siblings during block continuation
- Account for marker length when computing available wrap width
- Add CalculateMaxOwnerLength consideration for continuation owner ID
- Add tests: multiline values, long values, trailing newlines, sibling branch visibility during block continuation